### PR TITLE
Editgreeting: Allow commas to be in the greeting

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -1967,7 +1967,7 @@ exports.commands = {
 		arg = arg.split(',');
 		var type = toId(arg[0]);
 		if (!arg[1] || (type !== "public" && type !== "private")) return this.say(room, "Incorrect usage. ``(" + Config.commandcharacter + "editgreeting [public/private], New Greeting)``");
-		var newGreetingText = arg[1];
+		var newGreetingText = arg.slice(1).join(', ');
 		for (i = 0; i < this.settings.scribeShop.length; i++) {
 			if (this.settings.scribeShop[i].account === user.id) {
 				if (!this.settings.scribeShop[i].greetings) {


### PR DESCRIPTION
Previously, the variable 'newGreetingText' just took arg[1]. However, if there is a second comma, the description will only be set to what text is before that second comma. This should help fix that.

[19:29:27] #XTheElegantShadowX: ;editgreeting [public], Welcome, Master! May I drink your bathwater?
[19:29:27] *The Scribe: Greeting updated: Welcome