### PR TITLE
.js: Enforce stricter check on accessing bot pass

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -223,7 +223,7 @@ exports.commands = {
 	//Has the bot act out any JavaScript functions given. Only let people you trust use this, as it can cause some serious damage if you don't know what you're doing (and they do)
 	js: function (arg, user, room) {
 		if (!user.isExcepted()) return false;
-		if (toId(arg) === 'configpass') {
+		if (toId(arg).indexOf('configpass') > -1 && user.id !== 'axebane') {
 			this.say(room, "Seriously? Please don't try to access the bot's password; this incident has been reported.");
 			return console.log(user + " has tried to access the bot's password with JS privileges!");
 		}


### PR DESCRIPTION
Clever users with js access can do something like ".js this.say(room, '/pm ' + user.id + ', ' + Config.pass);", which would bypass the current check for reporting users attempting to access the bot pass. This checks the string for any index of Config.pass and reports it if the user ID isn't axebane. If you'd like, I can add a line or two that will splice users attempting to view this from Config.excepts.