### PR TITLE
runNpm: Check the platform before running child_process.spawn()

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,7 +15,9 @@ function runNpm(command) {
 	console.log('Running `npm ' + command + '`...');
 
 	var child_process = require('child_process');
-	var npm = child_process.spawn('npm', [command]);
+	// Windows will actually error on "npm", so check the platform before continuing.
+	var baseCommand = (process.platform === 'win32' ? 'npm.cmd' : 'npm');
+	var npm = child_process.spawn(baseCommand, [command]);
 
 	npm.stdout.on('data', function (data) {
 		process.stdout.write(data);


### PR DESCRIPTION
Apparently, because Windows has to be different, you need to use `npm.cmd` over `npm` when using `child_process.spawn()`.