### PR TITLE
Fix the getserver information

### DIFF
--- a/getserver.js
+++ b/getserver.js
@@ -35,14 +35,11 @@ if (process.argv[2]) {
 			if (index !== -1) {
 				var data = chunk.substr(index);
 				data = data.substr(search.length, data.indexOf(';') - search.length);
-				data = JSON.parse(data);
+				data = JSON.parse(JSON.parse(data));
 				console.log('---------------');
-				/*
 				console.log('server: ' + data.host);
 				console.log('port: ' + data.port);
 				console.log('serverid: ' + data.id);
-				*/
-				console.log(data); //Workaround because it stopped logging properly.
 			} else {
 				console.log('ERROR: failed to get data!');
 			}


### PR DESCRIPTION
The information is encoded twice by the server, so it needs to be parsed twice. It's been like this for a while, but I never got around to pulling a fix to it until you commented the stuff out.